### PR TITLE
add range checks for h3ToGeo

### DIFF
--- a/src/h3lib/lib/faceijk.c
+++ b/src/h3lib/lib/faceijk.c
@@ -490,6 +490,9 @@ void _hex2dToGeo(const Vec2d* v, int face, int res, int substrate,
  * @param g The spherical coordinates of the cell center point.
  */
 void _faceIjkToGeo(const FaceIJK* h, int res, GeoCoord* g) {
+    int baseCell = H3_GET_BASE_CELL(h->face);
+    if (baseCell < 0 || baseCell >= NUM_BASE_CELLS)
+        return;
     Vec2d v;
     _ijkToHex2d(&h->coord, &v);
     _hex2dToGeo(&v, h->face, res, 0, g);

--- a/src/h3lib/lib/h3Index.c
+++ b/src/h3lib/lib/h3Index.c
@@ -838,6 +838,9 @@ void _h3ToFaceIjk(H3Index h, FaceIJK* fijk) {
  * @param g The spherical coordinates of the H3 cell center.
  */
 void H3_EXPORT(h3ToGeo)(H3Index h3, GeoCoord* g) {
+    int baseCell = H3_GET_BASE_CELL(h3);
+    if (baseCell < 0 || baseCell >= NUM_BASE_CELLS)
+        return;
     FaceIJK fijk;
     _h3ToFaceIjk(h3, &fijk);
     _faceIjkToGeo(&fijk, H3_GET_RESOLUTION(h3), g);


### PR DESCRIPTION
Add range checks for the `h3ToGeo` functions in the h3 api library.
This relates to https://github.com/ClickHouse/ClickHouse/pull/24867 that adds the `h3ToGeo` function.

For large values like the one below, the server segfaults.
```sql
SELECT h3ToGeo(0xFFFFFFFFFFFFFF) FORMAT Null
```
Ensure that for large values of h3 index the buffer overflow is handled correctly.