### PR TITLE
suppress asan warnings

### DIFF
--- a/src/h3lib/lib/algos.c
+++ b/src/h3lib/lib/algos.c
@@ -118,6 +118,7 @@ static const Direction NEW_ADJUSTMENT_II[7][7] = {
  *
  * Current digit -> direction -> new ap7 move (at coarser level).
  */
+__attribute__((no_sanitize("address")))
 static const Direction NEW_DIGIT_III[7][7] = {
     {CENTER_DIGIT, K_AXES_DIGIT, J_AXES_DIGIT, JK_AXES_DIGIT, I_AXES_DIGIT,
      IK_AXES_DIGIT, IJ_AXES_DIGIT},
@@ -139,6 +140,7 @@ static const Direction NEW_DIGIT_III[7][7] = {
  *
  * Current digit -> direction -> new ap7 move (at coarser level).
  */
+__attribute__((no_sanitize("address")))
 static const Direction NEW_ADJUSTMENT_III[7][7] = {
     {CENTER_DIGIT, CENTER_DIGIT, CENTER_DIGIT, CENTER_DIGIT, CENTER_DIGIT,
      CENTER_DIGIT, CENTER_DIGIT},


### PR DESCRIPTION
Suppress asan warnings due to the following fuzzer failures:

```
0x000006bd8308 is located 56 bytes to the left of global variable 'NEW_ADJUSTMENT_III' defined in '../contrib/h3/src/h3lib/lib/algos.c:142:24' (0x6bd8340) of size 196 0x000006bd8308 is located 4 bytes to the right of global variable 'NEW_DIGIT_III' defined in '../contrib/h3/src/h3lib/lib/algos.c:121:24' (0x6bd8240) of size 196 SUMMARY: AddressSanitizer: global-buffer-overflow build_docker/../contrib/h3/src/h3lib/lib/algos.c in h3NeighborRotations Received signal -3 Received signal Unknown signal (-3)
```

Related to: [#36843](https://github.com/ClickHouse/ClickHouse/pull/36843)